### PR TITLE
Add normalize utility unit tests

### DIFF
--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import pytest
 
-from hyprland_ipc.ipc import Event, HyprlandIPC, HyprlandIPCError
+from hyprland_ipc.ipc import Event, HyprlandIPC, HyprlandIPCError, normalize
 
 
 # ---------------------------------------------------------------------------#
@@ -232,3 +232,24 @@ def test_events_iteration(cmd_server, evt_server) -> None:
     ipc_obj = HyprlandIPC(cmd_server, evt_server)
     events = list(ipc_obj.events())
     assert events == [Event("evt1", "data1"), Event("evt2", "data2")]
+
+
+# ---------------------------------------------------------------------------#
+#                                 normalize()                                #
+# ---------------------------------------------------------------------------#
+
+
+def test_normalize_returns_same_list() -> None:
+    data = [{"a": 1}, {"b": 2}]
+    assert normalize(data, "list") is data
+
+
+def test_normalize_wraps_dict_as_list() -> None:
+    data = {"k": "v"}
+    assert normalize(data, "list") == [data]
+
+
+@pytest.mark.parametrize("value", [None, "str", 1, [1, 2], 3.14])
+def test_normalize_invalid_inputs(value: object) -> None:
+    assert normalize(value, "list") == []
+    assert normalize(value, "dict") == {}


### PR DESCRIPTION
## Summary
- add unit tests for the `normalize` helper
- consolidate tests in `test_ipc.py`

## Testing
- `ruff check tests/test_ipc.py`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f7d407074832eb9266b5b939116e4